### PR TITLE
Use Benchmark.realtime to directly return a float rather than a string w...

### DIFF
--- a/lib/method_profiler/profiler.rb
+++ b/lib/method_profiler/profiler.rb
@@ -58,7 +58,6 @@ module MethodProfiler
     def profile(method, options = {}, &block)
       method_name = options[:singleton] ? ".#{method}" : "##{method}"
       elapsed_time, result = benchmark(block)
-      elapsed_time = elapsed_time.to_s.match(/\(\s*([^\)]+)\)/)[1].to_f
       @data[method_name] << elapsed_time
       result
     end
@@ -85,7 +84,7 @@ module MethodProfiler
 
     def benchmark(block_to_benchmark)
       result = nil
-      elapsed_time = Benchmark.measure { result = block_to_benchmark.call }
+      elapsed_time = Benchmark.realtime { result = block_to_benchmark.call }
       return elapsed_time, result
     end
   end

--- a/spec/method_profiler/report_spec.rb
+++ b/spec/method_profiler/report_spec.rb
@@ -7,7 +7,7 @@ describe MethodProfiler::Report do
     # Fake the timings for testing purposes
     profiler.stub(:benchmark) do |block_to_benchmark|
       result = block_to_benchmark.call
-      "(#{rand})"
+      rand
     end
 
     petition = Petition.new


### PR DESCRIPTION
...e have to parse.
